### PR TITLE
Improvements to libdragon sample ROM

### DIFF
--- a/Sample ROM/libdragon/catherineMdl.h
+++ b/Sample ROM/libdragon/catherineMdl.h
@@ -53,7 +53,7 @@ static s64Material mat_BootTex = {TYPE_TEXTURE, &matdata_BootTex, 1, 0, 1, 1, 1}
 static s64Texture matdata_ChestTex = {&ChestTex, 32, 64, GL_LINEAR, GL_REPEAT, GL_REPEAT};
 static s64Material mat_ChestTex = {TYPE_TEXTURE, &matdata_ChestTex, 1, 0, 1, 1, 1};
 
-static s64Texture matdata_KnifeSheatheTex = {&KnifeSheatheTex, 8, 64, GL_LINEAR, GL_REPEAT, GL_REPEAT};
+static s64Texture matdata_KnifeSheatheTex = {&KnifeSheatheTex, 8, 64, GL_LINEAR, GL_MIRRORED_REPEAT_ARB, GL_REPEAT};
 static s64Material mat_KnifeSheatheTex = {TYPE_TEXTURE, &matdata_KnifeSheatheTex, 1, 0, 0, 1, 1};
 
 static s64Texture matdata_PantsTex = {&PantsTex, 32, 64, GL_LINEAR, GL_REPEAT, GL_REPEAT};

--- a/Sample ROM/libdragon/main.c
+++ b/Sample ROM/libdragon/main.c
@@ -44,7 +44,7 @@ int main()
     
     // Initialize the screen    
     dfs_init(DFS_DEFAULT_LOCATION);
-    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 1, GAMMA_NONE, ANTIALIAS_RESAMPLE_FETCH_ALWAYS);
+    display_init(RESOLUTION_320x240, DEPTH_16_BPP, 2, GAMMA_NONE, ANTIALIAS_RESAMPLE_FETCH_ALWAYS);
 
     // Initialize OpenGL
     gl_init();
@@ -78,9 +78,8 @@ void setup()
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
     glEnable(GL_LIGHTING);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
+    glEnable(GL_ALPHA_TEST);
+    glAlphaFunc(GL_GREATER, 0.5f);
     glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, default_diffuse);
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, default_ambient);
     glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, default_specular);
@@ -95,19 +94,11 @@ void setup()
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
 
-    // Light
-    GLfloat light_pos[] = { 0, 0, 0, 1 };
+    // Light (directional)
+    GLfloat light_pos[] = { 0, 0, 1, 0 };
     glLightfv(GL_LIGHT0, GL_POSITION, light_pos);
     GLfloat light_diffuse[] = { 1, 1, 1, 1 };
     glLightfv(GL_LIGHT0, GL_DIFFUSE, light_diffuse);
-    glLightf(GL_LIGHT0, GL_CONSTANT_ATTENUATION, 0.0f);
-    glLightf(GL_LIGHT0, GL_QUADRATIC_ATTENUATION, 1.0f/10.0f);
-
-    // Fog
-    GLfloat fog_color[] = { 1, 0, 0, 1 };
-    glFogfv(GL_FOG_COLOR, fog_color);
-    glFogf(GL_FOG_START, 1.0f);
-    glFogf(GL_FOG_END, 6.0f);
 }
 
 void setup_catherine()
@@ -172,7 +163,6 @@ void render()
     // Initialize the buffer with a color
     glClearColor(0.3f, 0.1f, 0.6f, 1.f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glDepthMask(GL_TRUE);
     glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
 
     // Initialize our view
@@ -183,10 +173,8 @@ void render()
     // Apply a rotation to the scene
     glRotatef(45, 0, 1, 0);
     glRotatef(-90, 1, 0, 0);
-    glRotatef(0, 0, 0, 1);
     glPushMatrix();
 
     // Render our model
-    glDisable(GL_LIGHTING);
     sausage64_drawmodel(&catherine);
 }

--- a/Sample ROM/libdragon/sausage64.c
+++ b/Sample ROM/libdragon/sausage64.c
@@ -541,7 +541,6 @@ void sausage64_set_anim(s64ModelHelper* mdl, u16 anim)
             if (s64_lastmat == NULL || (s64_lastmat->type != TYPE_TEXTURE))
             {
                 const GLfloat diffuse[] = {1.0f, 1.0f, 1.0f, 1.0f};
-                glEnable(GL_TEXTURE);
                 glEnable(GL_TEXTURE_2D);
                 glEnable(GL_COLOR_MATERIAL);
                 glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, diffuse);
@@ -553,7 +552,6 @@ void sausage64_set_anim(s64ModelHelper* mdl, u16 anim)
             s64PrimColor* col = (s64PrimColor*)mat->data;
             if (s64_lastmat == NULL || (s64_lastmat->type != TYPE_PRIMCOL))
             {
-                glDisable(GL_TEXTURE);
                 glDisable(GL_TEXTURE_2D);
                 glDisable(GL_COLOR_MATERIAL);
             }


### PR DESCRIPTION
This contains several improvements to the libdragon sample ROM:
* Enable double buffering
* Fix the sheathed throwing knife by enabling mirrored repeat and alpha testing
* Fix the lighting by changing to a directional light
* Remove occurences of `glEnable(GL_TEXTURE)` (not a legal argument to glEnable)
* Remove some redundant code that doesn't do anything