### PR TITLE
libdragon example: improve depth precision

### DIFF
--- a/Sample ROM/libdragon/main.c
+++ b/Sample ROM/libdragon/main.c
@@ -122,7 +122,7 @@ void setup_scene()
     float aspect_ratio = (float)display_get_width()/(float)display_get_height();
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    glFrustum(-1*aspect_ratio, 1*aspect_ratio, -1, 1, 1, 300);
+    glFrustum(-20*aspect_ratio, 20*aspect_ratio, -20, 20, 20, 300);
 
     // Modelview matrix
     glMatrixMode(GL_MODELVIEW);


### PR DESCRIPTION
With the upcoming RSP implementation of the OpenGL pipeline, depth precision becomes a bigger issue due to fixed point calculations. This improves the depth precision by moving the near plane further forward. See also this article for some (partially applicable) advice on depth precision https://www.khronos.org/opengl/wiki/Depth_Buffer_Precision